### PR TITLE
feature: add suffix versioning support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,6 +36,13 @@ Add suffix ::
     Is this ok? y/n y
     Updated setup.py
 
+Bump suffix version ::
+
+    $ bump setup.py -s=-rc -S
+    1.1.0-rc.1 => 1.1.0-rc.2
+    Is this ok? y/n y
+    Updated setup.py
+
 Quiet mode ::
 
     $ bump setup.py -q

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='bump',
-    version='0.3.0',
+    version='0.4.0',
     description='Bumps package version numbers',
     long_description=open('README.rst').read(),
     license='MIT',


### PR DESCRIPTION
I liked bump, but needed versioning support for suffixes. e.g. "0.1.3-rc.1", "1.3.3-beta.1", et cetera. I updated bump.py to support just that.
